### PR TITLE
Multiple hit sounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ After logging in it should look like this:
 
 - *Reaction power:* How strong your model will react
 
-- *Play hit sound:* If a sound effect should be played when items hit your model
-  * Trashy loads the hit sound effect from `VTube Studio\BepInEx\plugins\Trashy\hit.mp3` Simply replace the file with any mp3 and press `Reload hit sound` in the Trashy settings
+- *Play hit sound:* If enabled, a sound effect will be played when items hit your model
 
 ### Setting up triggers
 
@@ -107,3 +106,16 @@ Groups are made by creating folders in `VTube Studio\BepInEx\plugins\Trashy\Item
 Example: Create a folder `pokemon` in `VTube Studio\BepInEx\plugins\Trashy\Items` and drop some png files into the `pokemon` folder. Now you have the group `pokemon` available in the trigger settings and it will only throw items from the `pokemon` folder.
 
 Make sure to click on `Reload Items` in the settings after adding or changing png files.
+
+### Additional hit sounds
+
+Trashy comes with a default hit sound, but you can replace it and/or add other sounds by just adding files to the `VTube Studio\BepInEx\plugins\Trashy\Sounds` folder, provided they are in one of these supported formats:
+
+ - `.mp3` MPEG Layer 3
+ - `.ogg` Ogg Vorbis (not Opus!)
+ - `.wav` Microsoft Wave
+ - `.aiff` Audio Interchange File Format
+
+Which sound is played when hit is chosen at random.
+
+If you add/remove sounds while VTube Studio is open, remember to click `Reload hit sounds` to apply the changes.

--- a/src/Trashy/Extensions.cs
+++ b/src/Trashy/Extensions.cs
@@ -113,6 +113,9 @@ namespace Trashy
             if (list.Count == 0)
                 return default;
 
+            if (list.Count == 1)
+                return list[0];
+
             return list[UnityEngine.Random.Range(0, list.Count)];
         }
     }

--- a/src/Trashy/SoundManager.cs
+++ b/src/Trashy/SoundManager.cs
@@ -93,6 +93,7 @@ namespace Trashy
 
         private async void Start()
         {
+            Migrate1();
             await LoadAudioClips();
             for (var i = 0; i < MaxSounds; ++i)
             {
@@ -137,6 +138,26 @@ namespace Trashy
                 default:
                     return AudioType.UNKNOWN;
             }
+        }
+
+        private static void Migrate1()
+        {
+            // Migrate from 0.3.3
+            // Sounds are now in Trashy/Sounds, move old hit.mp3 to that directory
+
+            var fileName = Path.Combine(Paths.PluginPath, "Trashy", "hit.mp3");
+            if (!File.Exists(fileName))
+                return;
+
+            var soundsDirectory = Path.Combine(Paths.PluginPath, "Trashy", "Sounds");
+            if (!Directory.Exists(soundsDirectory))
+                Directory.CreateDirectory(soundsDirectory);
+
+            var newFileName = Path.Combine(soundsDirectory, "hit.mp3");
+            if (File.Exists(newFileName))
+                File.Delete(newFileName);
+
+            File.Move(fileName, Path.Combine(soundsDirectory, "hit.mp3"));
         }
     }
 }

--- a/src/Trashy/SoundManager.cs
+++ b/src/Trashy/SoundManager.cs
@@ -48,17 +48,17 @@ namespace Trashy
             }
 
             // Load file
-            var request = UnityWebRequestMultimedia.GetAudioClip(
-                new Uri(fileName),
-                audioType
-            );
-            await request.SendWebRequest();
-            if (request.result != UnityWebRequest.Result.Success)
+            using (var request = UnityWebRequestMultimedia.GetAudioClip(new Uri(fileName), audioType))
             {
-                Log.Error<SoundManager>($"Unable to load audio file: {fileName}");
-                return null;
+                await request.SendWebRequest();
+                if (request.result != UnityWebRequest.Result.Success)
+                {
+                    Log.Error<SoundManager>($"Unable to load audio file: {fileName}");
+                    return null;
+                }
+
+                return DownloadHandlerAudioClip.GetContent(request);
             }
-            return DownloadHandlerAudioClip.GetContent(request);
         }
 
         public static async Task LoadAudioClips()

--- a/src/Trashy/SoundManager.cs
+++ b/src/Trashy/SoundManager.cs
@@ -77,11 +77,12 @@ namespace Trashy
             {
                 foreach (var audioClip in s_audioClips)
                     AudioClip.Destroy(audioClip);
+
                 s_audioClips.Clear();
             }
 
-            var itemsDirectory = Path.Combine(Paths.PluginPath, "Trashy", "Sounds");
-            foreach (var file in Directory.GetFiles(itemsDirectory, "*.*"))
+            var soundsDirectory = Path.Combine(Paths.PluginPath, "Trashy", "Sounds");
+            foreach (var file in Directory.GetFiles(soundsDirectory, "*.*"))
             {
                 // Load audio clip and add it to the list
                 var clip = await LoadClip(file);
@@ -117,14 +118,22 @@ namespace Trashy
 
         private static AudioType AudioTypeForFile(string fileName)
         {
-
             var extension = Path.GetExtension(fileName);
-            switch (extension)
+            switch (extension.ToLower())
             {
-                case ".wav": return AudioType.WAV;
-                case ".mp3": return AudioType.MPEG;
-                case ".ogg": return AudioType.OGGVORBIS;
-                case ".aiff": case ".aif": return AudioType.AIFF;
+                case ".wav":
+                    return AudioType.WAV;
+
+                case ".mp3":
+                    return AudioType.MPEG;
+
+                case ".ogg":
+                    return AudioType.OGGVORBIS;
+
+                case ".aiff":
+                case ".aif":
+                    return AudioType.AIFF;
+
                 default:
                     return AudioType.UNKNOWN;
             }

--- a/src/Trashy/UI/Windows/GeneralConfigWindow.cs
+++ b/src/Trashy/UI/Windows/GeneralConfigWindow.cs
@@ -100,8 +100,8 @@ namespace Trashy.UI
                 if (GUILayout.Button("Reload Items"))
                     _spriteManager.Load();
 
-                if (GUILayout.Button("Reload hit sound"))
-                    await SoundManager.LoadAudioClip();
+                if (GUILayout.Button("Reload hit sounds"))
+                    await SoundManager.LoadAudioClips();
 
                 if (TwitchAuth.IsValidating)
                 {


### PR DESCRIPTION
Volume warning: https://streamable.com/pbmzuk

## What is this

Adds additional hit sounds, stored in a `Sounds` folder just like items are in a `Items` folder.

Right now they are loaded in a list (tried to match items code) and picked at random when needed, there's no support for grouping or associating a sound to a specific item. If that's desirable I can look into it but for my needs specifically this is already fine so I didn't bother.

**Important**: This requires `hit.mp3` to be moved in the `Sounds` folder! Not just for packaging releases but probably worth writing in the release notes as well, since if someone is upgrading from an earlier version and replace the stock one with their own they probably wanna know.

This is my first time contributing to this project (or a Unity mod in general) so please tell me if I did something dumb!

## Why

I like having multiple items, but it made little sense to me that we couldn't have multiple sounds too!